### PR TITLE
Add Endstone

### DIFF
--- a/src/main/java/com/earthpol/epcore/Main.java
+++ b/src/main/java/com/earthpol/epcore/Main.java
@@ -227,7 +227,7 @@ public final class Main extends JavaPlugin {
         Bukkit.addRecipe(netherrack);
         
         //Endstone
-        final ShapedRecipe endstone = new ShapedRecipe(new NamespacedKey(this, "custom_endstone"), new ItemStack(Material.ENDSTONE, 8));
+        final ShapedRecipe endstone = new ShapedRecipe(new NamespacedKey(this, "custom_endstone"), new ItemStack(Material.END_STONE, 8));
         endstone.shape("CCC", "CDC", "CCC");
         endstone.setIngredient('C', Material.COBBLESTONE);
         endstone.setIngredient('D', Material.WHITE_DYE);

--- a/src/main/java/com/earthpol/epcore/Main.java
+++ b/src/main/java/com/earthpol/epcore/Main.java
@@ -225,6 +225,13 @@ public final class Main extends JavaPlugin {
         netherrack.setIngredient('S', Material.STONE);
         netherrack.setIngredient('D', Material.RED_DYE);
         Bukkit.addRecipe(netherrack);
+        
+        //Endstone
+        final ShapedRecipe endstone = new ShapedRecipe(new NamespacedKey(this, "custom_endstone"), new ItemStack(Material.ENDSTONE, 8));
+        endstone.shape("CCC", "CDC", "CCC");
+        endstone.setIngredient('C', Material.COBBLESTONE);
+        endstone.setIngredient('D', Material.WHITE_DYE);
+        Bukkit.addRecipe(endstone);
 
         //Crimson Nylium
         final ShapelessRecipe crimsonNylium = new ShapelessRecipe(new NamespacedKey(this, "custom_crimson_nylium"), new ItemStack(Material.CRIMSON_NYLIUM, 1));


### PR DESCRIPTION
Reasoning for adding Endstone:
1. Adding just the endstone block will make it possible to craft all the other endstone blocks like stairs and slabs and bricks
2. Endstone is an epic building material especially for medieval builds because it looks like a limestone
3. There is no possible way that there could be any negative effect on the server just for adding another building block, it is the only use of endstone. The only other thing special about endstone is it's high blast resistance.

Reasoning for Recipe:
The recipe is a white dye surrounded by cobble. 
1. Endstone was originally going to be added to Minecraft as white cobblestone, and this is why the texture is so similar, according to the wiki: https://minecraft.fandom.com/wiki/End_Stone#History
2. The difficulty of this crafting recipe is similar in difficulty to the crafting recipe of the other common dimensional stone block, netherrack. The difference is this uses cobble stone instead of regular stone and white dye instead of red dye.